### PR TITLE
Adds compiler flag driven debugging functions

### DIFF
--- a/flipstone-prelude.cabal
+++ b/flipstone-prelude.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 587cb573f80a444d3f50aa820ffdfdca15932c203b0169e211aef6fd65648f92
+-- hash: 0144d5125fd286e747528ceb47a26c122dcdd4c5f3d40305fb3c2b1d7b138b82
 
 name:           flipstone-prelude
 version:        0.1.0.0
@@ -25,6 +25,11 @@ source-repository head
   type: git
   location: https://github.com/flipstone/flipstone-prelude
 
+flag debug
+  description: _
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Flipstone.Debug
@@ -42,4 +47,6 @@ library
     , either
     , text
     , type-errors
+  if flag(debug)
+    cpp-options: -DDEBUG
   default-language: Haskell2010

--- a/flipstone-prelude.cabal
+++ b/flipstone-prelude.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d1bdc593f9022e1b0777bdf017b3b4ff262013c586e9a682fc988ab4a8dec9b6
+-- hash: 587cb573f80a444d3f50aa820ffdfdca15932c203b0169e211aef6fd65648f92
 
 name:           flipstone-prelude
 version:        0.1.0.0
@@ -34,10 +34,12 @@ library
   hs-source-dirs:
       src
   default-extensions:
+      CPP
       NoImplicitPrelude
   build-depends:
       base >=4.7 && <5
     , containers
     , either
     , text
+    , type-errors
   default-language: Haskell2010

--- a/flipstone-prelude.cabal
+++ b/flipstone-prelude.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5c5e3f9340e425724ef97c2ca24bfa46cf645c37aa2f57358d1e51e67a18c96e
+-- hash: d1bdc593f9022e1b0777bdf017b3b4ff262013c586e9a682fc988ab4a8dec9b6
 
 name:           flipstone-prelude
 version:        0.1.0.0
@@ -27,12 +27,14 @@ source-repository head
 
 library
   exposed-modules:
+      Flipstone.Debug
       Flipstone.Prelude
   other-modules:
       Paths_flipstone_prelude
   hs-source-dirs:
       src
-  default-extensions: NoImplicitPrelude
+  default-extensions:
+      NoImplicitPrelude
   build-depends:
       base >=4.7 && <5
     , containers

--- a/package.yaml
+++ b/package.yaml
@@ -11,6 +11,7 @@ extra-source-files:
   - ChangeLog.md
 
 default-extensions:
+  - CPP
   - NoImplicitPrelude
 
 description:         Please see the README on GitHub at <https://github.com/flipstone/flipstone-prelude#readme>
@@ -20,6 +21,7 @@ dependencies:
   - containers
   - either
   - text
+  - type-errors
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -23,5 +23,14 @@ dependencies:
   - text
   - type-errors
 
+flags:
+  debug:
+    description: Exposes debugging functions for use in development environments.
+    manual: true
+    default: false
+
 library:
   source-dirs: src
+  when:
+    - condition: flag(debug)
+      cpp-options: -DDEBUG

--- a/src/Flipstone/Debug.hs
+++ b/src/Flipstone/Debug.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE CPP #-}
+module Flipstone.Debug
+  ( trace
+  , traceIO
+  , traceShowId
+  , traceShowM
+  , traceStack
+  , undefined
+  ) where
+
+#ifdef DEV
+-- This exposes the true versions of the debug functions for use in development
+-- environments. They will only compile if there is a `-DDEV` compiler flag
+-- present.
+import Debug.Trace (trace, traceIO, traceShowId, traceShowM, traceStack)
+import GHC.Err (undefined)
+
+#else
+-- This exposes bunk versions of the debug functions that will always fail to
+-- compile when used.
+import qualified GHC.Err as Err
+
+data DevFlagNotSet
+
+{-# WARNING trace, traceIO, traceShowId, traceShowM, traceStack, undefined
+    "Debug functions may only be used in development."
+  #-}
+
+trace :: DevFlagNotSet
+trace = Err.undefined
+
+traceIO :: DevFlagNotSet
+traceIO = Err.undefined
+
+traceShowId :: DevFlagNotSet
+traceShowId = Err.undefined
+
+traceShowM :: DevFlagNotSet
+traceShowM = Err.undefined
+
+traceStack :: DevFlagNotSet
+traceStack = Err.undefined
+
+undefined :: DevFlagNotSet
+undefined = Err.undefined
+
+#endif

--- a/src/Flipstone/Debug.hs
+++ b/src/Flipstone/Debug.hs
@@ -1,4 +1,10 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Flipstone.Debug
   ( trace
   , traceIO
@@ -18,30 +24,35 @@ import GHC.Err (undefined)
 #else
 -- This exposes bunk versions of the debug functions that will always fail to
 -- compile when used.
+import Data.Kind (Constraint, Type)
 import qualified GHC.Err as Err
+import Type.Errors (TypeError, ErrorMessage(Text, (:$$:), (:<>:)))
 
-data DevFlagNotSet
+class DevFlagNotSetError (msg :: ErrorMessage)
+instance TypeError msg => DevFlagNotSetError msg
 
-{-# WARNING trace, traceIO, traceShowId, traceShowM, traceStack, undefined
-    "Debug functions may only be used in development."
-  #-}
+type DevFlagNotSetMessage =
+  'Text "Debugging functions are only permitted in development "         ':$$:
+  'Text "environments. In order to use this function, you must set the " ':$$:
+  'Text "DEV flag when loading the REPL. This flag must never be used "  ':$$:
+  'Text "in any live environment. "
 
-trace :: DevFlagNotSet
-trace = Err.undefined
+trace :: DevFlagNotSetError DevFlagNotSetMessage => a
+trace = Err.error "unreachable"
 
-traceIO :: DevFlagNotSet
-traceIO = Err.undefined
+traceIO :: DevFlagNotSetError DevFlagNotSetMessage => a
+traceIO = Err.error "unreachable"
 
-traceShowId :: DevFlagNotSet
-traceShowId = Err.undefined
+traceShowId :: DevFlagNotSetError DevFlagNotSetMessage => a
+traceShowId = Err.error "unreachable"
 
-traceShowM :: DevFlagNotSet
-traceShowM = Err.undefined
+traceShowM :: DevFlagNotSetError DevFlagNotSetMessage => a
+traceShowM = Err.error "unreachable"
 
-traceStack :: DevFlagNotSet
-traceStack = Err.undefined
+traceStack :: DevFlagNotSetError DevFlagNotSetMessage => a
+traceStack = Err.error "unreachable"
 
-undefined :: DevFlagNotSet
-undefined = Err.undefined
+undefined :: DevFlagNotSetError DevFlagNotSetMessage => a
+undefined = Err.error "unreachable"
 
 #endif

--- a/src/Flipstone/Debug.hs
+++ b/src/Flipstone/Debug.hs
@@ -14,10 +14,10 @@ module Flipstone.Debug
   , undefined
   ) where
 
-#ifdef DEV
+#ifdef DEBUG
 -- This exposes the true versions of the debug functions for use in development
--- environments. They will only compile if there is a `-DDEV` compiler flag
--- present.
+-- environments. They will only compile if there is a `-DDEBUG` compiler flag
+-- present. To set this, run with the command `--flag flipstone-prelude:debug`.
 import Debug.Trace (trace, traceIO, traceShowId, traceShowM, traceStack)
 import GHC.Err (undefined)
 
@@ -32,10 +32,11 @@ class DevFlagNotSetError (msg :: ErrorMessage)
 instance TypeError msg => DevFlagNotSetError msg
 
 type DevFlagNotSetMessage =
-  'Text "Debugging functions are only permitted in development "         ':$$:
-  'Text "environments. In order to use this function, you must set the " ':$$:
-  'Text "DEV flag when loading the REPL. This flag must never be used "  ':$$:
-  'Text "in any live environment. "
+  'Text "Debugging functions are only permitted in development"         ':$$:
+  'Text "environments. In order to use this function, you must set the" ':$$:
+  'Text "DEBUG flag when loading the REPL. You can set this by running" ':$$:
+  'Text "with the command `--flag flipstone-prelude:debug`. This flag"  ':$$:
+  'Text "must never be used in any live environment."
 
 trace :: DevFlagNotSetError DevFlagNotSetMessage => a
 trace = Err.error "unreachable"

--- a/src/Flipstone/Prelude.hs
+++ b/src/Flipstone/Prelude.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Flipstone.Prelude
  (
  -- Concrete types and related functions

--- a/src/Flipstone/Prelude.hs
+++ b/src/Flipstone/Prelude.hs
@@ -179,13 +179,12 @@ import Data.String (String, IsString (fromString))
 import Data.Text (Text)
 import Data.Traversable ( Traversable(traverse, sequenceA) )
 import Data.Word ( Word, Word8, Word16, Word32, Word64 )
-import Debug.Trace (trace, traceIO, traceShowId, traceShowM, traceStack)
+import Flipstone.Debug ( trace , traceIO , traceShowId , traceShowM , traceStack , undefined)
 import GHC.Enum ( Bounded(minBound, maxBound)
                 , Enum(succ, pred, toEnum, fromEnum, enumFrom, enumFromThen, enumFromTo, enumFromThenTo)
                 , boundedEnumFrom
                 , boundedEnumFromThen
                 )
-import GHC.Err (undefined)
 import GHC.IO ( IO )
 import GHC.Num ( Num((+), (-), (*), negate, abs, signum, fromInteger), Integer, subtract )
 import GHC.Real( fromIntegral


### PR DESCRIPTION
This adds a new module `Flipstone.Debug`, which conditionally
exports debugging functions with different type signatures
depending on the presence of a `DEV` compiler flag. When the flag
is present, the debugging functions have the expected behavior.
When the flag is not present, they instead will have a type
`DevFlagNotSet` that won't match and will cause the app to fail.

Co-authored-by: Ava <ava@flipstone.com>
Co-authored-by: James <james@flipstone.com>