### PR TITLE
Removes Set, Text and NonEmpty re-exports

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,6 @@ description:         Please see the README on GitHub at <https://github.com/flip
 
 dependencies:
   - base >= 4.7 && < 5
-  - containers
   - either
   - text
   - type-errors

--- a/src/Flipstone/Prelude.hs
+++ b/src/Flipstone/Prelude.hs
@@ -30,11 +30,6 @@ module Flipstone.Prelude
 
  -- Parameterized types
 
- -- Types that we only re-export the Type not associated functions
- , Set
- , NonEmpty
- , Text
-
  -- Maybe and related functions
  , Maybe(Just, Nothing)
  , maybe
@@ -169,13 +164,10 @@ import Data.Functor (Functor(fmap, (<$)), (<$>), void)
 import Data.Int (Int, Int8, Int16, Int32, Int64)
 import Data.Maybe ( Maybe(Just, Nothing), maybe )
 import Data.Monoid ( Monoid(mconcat, mempty) )
-import Data.List.NonEmpty (NonEmpty)
 import Data.Ord ( Ord(compare, (<), (<=), (>), (>=), max, min), Ordering(LT, EQ, GT) )
 import Data.Ratio ( Ratio, Rational )
 import Data.Semigroup ( Semigroup((<>), sconcat, stimes))
-import Data.Set (Set)
 import Data.String (String, IsString (fromString))
-import Data.Text (Text)
 import Data.Traversable ( Traversable(traverse, sequenceA) )
 import Data.Word ( Word, Word8, Word16, Word32, Word64 )
 import Flipstone.Debug ( trace , traceIO , traceShowId , traceShowM , traceStack , undefined)


### PR DESCRIPTION
Re-exporting these from the prelude cause us to have unconventially use
these types unqualified. Additionally, if we just don't re-export `Set` and
`Text` then we can remove the entire package dependency on `containers`

With this change we'll be able to use `Flipstone.Prelude` imports in
modules with qualified Text imports only referencing the type without
any warnings again.
