### PR TITLE
Adds `foldMapA` and `foldMapA1`

### DIFF
--- a/flipstone-prelude.cabal
+++ b/flipstone-prelude.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           flipstone-prelude
-version:        0.3.1.0
+version:        0.3.2.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/flipstone-prelude#readme>
 homepage:       https://github.com/flipstone/flipstone-prelude#readme
 bug-reports:    https://github.com/flipstone/flipstone-prelude/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                flipstone-prelude
-version:             0.3.1.0
+version:             0.3.2.0
 github:              "flipstone/flipstone-prelude"
 license:             MIT
 author:              "Flipstone Technology Partners"


### PR DESCRIPTION
These are variants of `foldMap` that combine monoid/semigroup values inside of an applicative using `liftA2 (<>)`. They can be used to do things like `fmap mconcat . traverse f` in a single traversal.