### PR TITLE
Require GHC 9.6 or newer

### DIFF
--- a/flipstone-prelude.cabal
+++ b/flipstone-prelude.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           flipstone-prelude
-version:        0.3.2.0
+version:        0.3.3.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/flipstone-prelude#readme>
 homepage:       https://github.com/flipstone/flipstone-prelude#readme
 bug-reports:    https://github.com/flipstone/flipstone-prelude/issues
@@ -40,12 +40,9 @@ library
       CPP
       NoImplicitPrelude
   build-depends:
-      base >=4.7 && <5
+      base >=4.18 && <5
     , either
     , type-errors
   default-language: Haskell2010
-  if impl(ghc < 9.6.1)
-    build-depends:
-        foldable1-classes-compat
   if flag(debug)
     cpp-options: -DDEBUG

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                flipstone-prelude
-version:             0.3.2.0
+version:             0.3.3.0
 github:              "flipstone/flipstone-prelude"
 license:             MIT
 author:              "Flipstone Technology Partners"
@@ -17,13 +17,9 @@ default-extensions:
 description:         Please see the README on GitHub at <https://github.com/flipstone/flipstone-prelude#readme>
 
 dependencies:
-  - base >= 4.7 && < 5
+  - base >= 4.18 && < 5
   - either
   - type-errors
-
-when:
-  condition: impl(ghc < 9.6.1)
-  dependencies: foldable1-classes-compat
 
 flags:
   debug:

--- a/src/Flipstone/Prelude.hs
+++ b/src/Flipstone/Prelude.hs
@@ -78,10 +78,7 @@ module Flipstone.Prelude
  -- Fold and traversal typeclasses and functions
  , Traversable(traverse, sequenceA)
  , Foldable(
-#if MIN_VERSION_base(4,13,0)
-   foldMap',
-#endif
-   fold, foldMap, foldr, foldr', foldl', toList, null, length, elem, sum, product
+   fold, foldMap, foldMap', foldr, foldr', foldl', toList, null, length, elem, sum, product
  )
  -- ^ `foldl` is considered dangerous, also omitted are the functions which will throw, `foldr1` and `foldl1`
  , and
@@ -174,10 +171,7 @@ import Data.Either ( Either(Left, Right), either, lefts, rights, isLeft, isRight
 import Data.Either.Combinators (fromLeft, fromRight, mapBoth, mapLeft, mapRight )
 import Data.Eq ( Eq((==), (/=)) )
 import Data.Foldable ( Foldable(
-#if MIN_VERSION_base(4,13,0)
-                                 foldMap',
-#endif
-                                 fold, foldMap, foldr, foldr', foldl', toList, null, length, elem, maximum, sum, product
+                                 fold, foldMap, foldMap', foldr, foldr', foldl', toList, null, length, elem, maximum, sum, product
                                )
                      , and
                      , or
@@ -223,10 +217,7 @@ import Data.Function (id, const, (.), flip, ($))
 import Data.Functor (Functor(fmap, (<$)), (<$>), void)
 import Data.Int (Int, Int8, Int16, Int32, Int64)
 import Data.Maybe ( Maybe(Just, Nothing), maybe )
-import Data.Monoid ( Monoid(mconcat, mempty) )
-#if MIN_VERSION_base(4,12,0)
-import Data.Monoid (Ap(..))
-#endif
+import Data.Monoid ( Ap(..), Monoid(mconcat, mempty) )
 import Data.List.NonEmpty (NonEmpty)
 import Data.Ord ( Ord(compare, (<), (<=), (>), (>=), max, min), Ordering(LT, EQ, GT) )
 import Data.Ratio ( Ratio, Rational )
@@ -258,15 +249,7 @@ ffmap :: (Functor f, Functor g)
 ffmap = fmap . fmap
 
 foldMapA :: forall f t a b. (Monoid b, Applicative f, Foldable t) => (a -> f b) -> t a -> f b
-#if MIN_VERSION_base(4,12,0)
 foldMapA = coerce (foldMap :: (a -> Ap f b) -> t a -> Ap f b)
-#else
-foldMapA f = foldr (liftA2 (<>) . f) (pure mempty)
-#endif
 
 foldMapA1 :: forall f t a b. (Semigroup b, Applicative f, Foldable1 t) => (a -> f b) -> t a -> f b
-#if MIN_VERSION_base(4,12,0)
 foldMapA1 = coerce (foldMap1 :: (a -> Ap f b) -> t a -> Ap f b)
-#else
-foldMapA1 f = foldrMap1 f (liftA2 (<>) . f)
-#endif


### PR DESCRIPTION
Instead of having a bogus lower bound, let's put the actual required minimum
version there. Since GHC 9.6 has been in production use for a while now, let's
make this the minimum supported version. Any consumers that need compatibility
with lower versions of GHC, please create an issue, and we can lower the
required minimum bound.
